### PR TITLE
Fix DNS server start in AP mode

### DIFF
--- a/wifiupdate.h
+++ b/wifiupdate.h
@@ -26,7 +26,7 @@ class wifiupdate {
           WiFi.mode(WIFI_AP);
           WiFi.softAP(CONFIG_WIFI_SSID, CONFIG_WIFI_PASSWORD);  
           MDNS.begin("SSD_FPV_SCANER"); 
-          dnsServer.start();
+          dnsServer.start(53, "*", WiFi.softAPIP());
           inits = 1;
           webServerInit();
       }


### PR DESCRIPTION
## Summary
- start the DNS server with the device's IP address when entering AP mode

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0f11ae0483339fca4f890de1463d