### PR TITLE
Clean up PlatformIO configuration

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,6 +1,4 @@
 [env:ttgo]
-src_dir = src
-include_dir = include
 platform = espressif32
 board = ttgo-lora32-v1
 framework = arduino


### PR DESCRIPTION
## Summary
- remove obsolete `src_dir` and `include_dir` from `platformio.ini`

## Testing
- `pio run` *(fails: HTTPClientError due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685f1d7a82548333a0e6c01d642fdfd9